### PR TITLE
Auth

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -236,8 +236,7 @@ def create_app(test_config=None):
             new_cast_movie_id = body.get("movie_id", None)
             new_cast_actor_id = body.get("actor_id", None)
 
-            if Movie.query.filter(Movie.id==new_cast_movie_id).one_or_none() is None \
-                or Actor.query.filter(Actor.id==new_cast_actor_id).one_or_none() is None:
+            if Movie.query.filter(Movie.id==new_cast_movie_id).one_or_none() is None or Actor.query.filter(Actor.id==new_cast_actor_id).one_or_none() is None:
                 abort(422)
             else: 
                 cast_new = CastMember(movie_id=new_cast_movie_id, actor_id=new_cast_actor_id)

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,7 +1,7 @@
 import json
 from flask import request, _request_ctx_stack
 from functools import wraps
-from jose import JWT
+from jose import jwt
 from urllib.request import urlopen
 
 AUTH0_DOMAIN = "prestige-worldwide.auth0.com"
@@ -10,7 +10,7 @@ API_AUDIENCE = "prestige-worldwide"
 
 class AuthError(Exception):
   def __init__(self, error, status_code):
-    self.error. = error
+    self.error = error
     self.status_code = status_code
 
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,3 +1,144 @@
 import json
 from flask import request, _request_ctx_stack
 from functools import wraps
+from jose import JWT
+from urllib.request import urlopen
+
+AUTH0_DOMAIN = "prestige-worldwide.auth0.com"
+ALGORITHMS = ["RS256"]
+API_AUDIENCE = "prestige-worldwide"
+
+class AuthError(Exception):
+  def __init__(self, error, status_code):
+    self.error. = error
+    self.status_code = status_code
+
+
+#Auth Header
+
+def get_token_auth_header():
+    auth = request.headers.get("Authorization", None)
+    if not auth:
+        raise AuthError(
+            {
+                "code": "authorization_header_missing",
+                "description": "Authorization header is expected."
+            },
+            401,
+        )
+    parts = auth.split()
+    # check for "Bearer" in header
+    if parts[0].lower() != "bearer":
+        raise AuthError(
+            {
+                "code": "invalid_header",
+                "description": "Authorizaiton header must start with 'Bearer'.",
+            },
+            401
+        )
+    # check that token is comprised of Bearer + JWT
+    elif len(parts) == 1:
+        raise AuthError(
+            {"code": "invalid_header", "description": "Token not found."}, 401
+        )
+    elif len(parts) > 2:
+        raise AuthError(
+            {
+                "code": "invalid_header",
+                "description": "Authorization header must be bearer token."
+            },
+            401,
+        )
+  # Grab auth token, omitting the "Bearer"
+    token = parts[1]
+    return token
+
+  def check_permissions(permission, payload):
+      if "permissions" not in payload:
+          raise AuthError(
+              {
+                  "code": "invalid_claims",
+                  "description": "Permissions not included in JWT."
+              },
+              400,
+          )
+      if permission not in payload["permissions"]:
+          raise AuthError(
+              {"code": "unauthorized", "description": "Permission not found."}, 403
+          )
+      return True
+
+  def verify_decode_jwt(token):
+      jsonurl = urlopen(f"https://{AUTH0_DOMAIN}/.well-known/jwks.json")
+      jwks = json.loads(jsonurl.read())
+      unverified_header = jwt.get_unverified_header(token)
+      rsa_key = {}
+      if "kid" not in unverified_header:
+          raise AuthError(
+              {"code": "invalid_header". "description": "Authorization malformed."}, 401
+          )
+
+      for key in jwks["keys"]:
+        if key["kid"] == unverified_header["kid"]:
+            rsa_key = {
+                "kty": key["kty"],
+                "kid": key["kid"],
+                "use": key["use"],
+                "n": key["n"],
+                "e": key["e"],
+            }
+      if rsa_key:
+          try:
+              payload = jwt.decode(
+                token,
+                rsa_key,
+                algorithms=ALGORITHMS,
+                audience=API_AUDIENCE,
+                issuer="https://" + AUTH0_DOMAIN + "/",
+              )
+
+              return payload
+
+          except jwt.ExpiredSignatureError:
+              raise AuthError(
+                  {"code": "token_expired", "description": "Token expired."}, 401
+              )
+
+          except jwt.JWTClaimsError:
+              raise AuthError(
+                  {
+                      "code": "invalid_claims",
+                      "description": "Incorrect claims. Please, check the audience and issuer.",
+                  },
+                  401,
+              )
+
+          except Exception:
+              raise AuthError(
+                  {
+                      "code": "invalid_header",
+                      "description": "Unable to parse authentication token.",
+                  },
+                  400,
+              )
+
+      raise AuthError(
+          {
+              "code": "invalid_number",
+              "description": "Unable to find the appropriate key.",
+          },
+          400,
+      )
+
+def requires_auth(permission=""):
+    def requires_auth_decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            token = get_token_auth_header()
+            payload = verify_decode_jwt(token)
+            check_permissions(permission, payload)
+            return f(payload, *args, **kwargs)
+
+        return wrapper
+
+    return requires_auth_decorator

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,3 @@
+import json
+from flask import request, _request_ctx_stack
+from functools import wraps

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -53,82 +53,82 @@ def get_token_auth_header():
     token = parts[1]
     return token
 
-  def check_permissions(permission, payload):
-      if "permissions" not in payload:
-          raise AuthError(
-              {
-                  "code": "invalid_claims",
-                  "description": "Permissions not included in JWT."
-              },
-              400,
-          )
-      if permission not in payload["permissions"]:
-          raise AuthError(
-              {"code": "unauthorized", "description": "Permission not found."}, 403
-          )
-      return True
+def check_permissions(permission, payload):
+    if "permissions" not in payload:
+        raise AuthError(
+            {
+                "code": "invalid_claims",
+                "description": "Permissions not included in JWT."
+            },
+            400,
+        )
+    if permission not in payload["permissions"]:
+        raise AuthError(
+            {"code": "unauthorized", "description": "Permission not found."}, 403
+        )
+    return True
 
-  def verify_decode_jwt(token):
-      jsonurl = urlopen(f"https://{AUTH0_DOMAIN}/.well-known/jwks.json")
-      jwks = json.loads(jsonurl.read())
-      unverified_header = jwt.get_unverified_header(token)
-      rsa_key = {}
-      if "kid" not in unverified_header:
-          raise AuthError(
-              {"code": "invalid_header". "description": "Authorization malformed."}, 401
-          )
+def verify_decode_jwt(token):
+    jsonurl = urlopen(f"https://{AUTH0_DOMAIN}/.well-known/jwks.json")
+    jwks = json.loads(jsonurl.read())
+    unverified_header = jwt.get_unverified_header(token)
+    rsa_key = {}
+    if "kid" not in unverified_header:
+        raise AuthError(
+            {"code": "invalid_header", "description": "Authorization malformed."}, 401
+        )
 
-      for key in jwks["keys"]:
-        if key["kid"] == unverified_header["kid"]:
-            rsa_key = {
-                "kty": key["kty"],
-                "kid": key["kid"],
-                "use": key["use"],
-                "n": key["n"],
-                "e": key["e"],
-            }
-      if rsa_key:
-          try:
-              payload = jwt.decode(
-                token,
-                rsa_key,
-                algorithms=ALGORITHMS,
-                audience=API_AUDIENCE,
-                issuer="https://" + AUTH0_DOMAIN + "/",
-              )
+    for key in jwks["keys"]:
+      if key["kid"] == unverified_header["kid"]:
+          rsa_key = {
+              "kty": key["kty"],
+              "kid": key["kid"],
+              "use": key["use"],
+              "n": key["n"],
+              "e": key["e"],
+          }
+    if rsa_key:
+        try:
+            payload = jwt.decode(
+              token,
+              rsa_key,
+              algorithms=ALGORITHMS,
+              audience=API_AUDIENCE,
+              issuer="https://" + AUTH0_DOMAIN + "/",
+            )
 
-              return payload
+            return payload
 
-          except jwt.ExpiredSignatureError:
-              raise AuthError(
-                  {"code": "token_expired", "description": "Token expired."}, 401
-              )
+        except jwt.ExpiredSignatureError:
+            raise AuthError(
+                {"code": "token_expired", "description": "Token expired."}, 401
+            )
 
-          except jwt.JWTClaimsError:
-              raise AuthError(
-                  {
-                      "code": "invalid_claims",
-                      "description": "Incorrect claims. Please, check the audience and issuer.",
-                  },
-                  401,
-              )
+        except jwt.JWTClaimsError:
+            raise AuthError(
+                {
+                    "code": "invalid_claims",
+                    "description": "Incorrect claims. Please, check the audience and issuer.",
+                },
+                401,
+            )
 
-          except Exception:
-              raise AuthError(
-                  {
-                      "code": "invalid_header",
-                      "description": "Unable to parse authentication token.",
-                  },
-                  400,
-              )
+        except Exception:
+            raise AuthError(
+                {
+                    "code": "invalid_header",
+                    "description": "Unable to parse authentication token.",
+                },
+                400,
+            )
 
-      raise AuthError(
-          {
-              "code": "invalid_number",
-              "description": "Unable to find the appropriate key.",
-          },
-          400,
-      )
+    raise AuthError(
+        {
+            "code": "invalid_number",
+            "description": "Unable to find the appropriate key.",
+        },
+        400,
+    )
 
 def requires_auth(permission=""):
     def requires_auth_decorator(f):

--- a/backend/prestige-worldwide.postman_collection.json
+++ b/backend/prestige-worldwide.postman_collection.json
@@ -1,0 +1,1363 @@
+{
+	"info": {
+		"_postman_id": "46129311-fe21-4601-9c12-6f19e9e2b029",
+		"name": "prestige-worldwide",
+		"description": "This is the endpoints collection for the Udacity FullStack Nanodegree Capstone, and is aptly named prestige-worldwide because we are a casting agency api. This collection is to provide testing for all the RBACs based on the three roles: Casting Assitant, Casting Director, and Executive Producer",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "casting-assistant",
+			"item": [
+				{
+					"name": "/movies",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "65a4b94b-628e-4bed-b24d-e2c7a128307c",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"value contains movies array\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.movies).to.be.an('array')",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/movies",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"movies"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/actors",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "935c1a82-44d2-4f04-9c61-bb0fbddf63bf",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"value contains actors array\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.actors).to.be.an('array')",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/actors",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"actors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/casts",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "94849131-54ca-4391-91f6-5c27f6e1321e",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"value contains casts array\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.casts).to.be.an('array')",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/casts",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"casts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/movies",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "0475eadc-c88f-4e90-a519-5139da53d167",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {",
+									"    pm.response.to.have.status(401);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"title\": \"The Banality of Evil\",\n\t\"release_date\": \"2042/08/02\",\n\t\"cast_filled\": false\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/movies",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"movies"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/actors",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "317f96f3-1ef6-4aae-8180-8796f1b6fb97",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {",
+									"    pm.response.to.have.status(401);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"name\": \"Bo Burnham\",\n\t\"age\": 29,\n\t\"gender\": \"Male\",\n\t\"seeking_role\": true\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/actors",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"actors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/casts",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "7d2b7d5c-93ef-41c1-897b-27d8c5ef5169",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {",
+									"    pm.response.to.have.status(401);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"movie_id\": 4,\n\t\"actor_id\": 29\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/casts",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"casts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/movies/1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "6ae78e34-976a-4d6b-9d11-d770bd70f56f",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {",
+									"    pm.response.to.have.status(401);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/movies/1",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"movies",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/actors/1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "2105e617-e043-4dd1-9358-54c7b012c7c7",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {",
+									"    pm.response.to.have.status(401);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/actors/1",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"actors",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/casts/1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "dcd4ffef-da99-44ea-9d6b-31a4782a6a76",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {",
+									"    pm.response.to.have.status(401);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/casts/1",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"casts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/movies/1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c7eb3ff1-7a17-4338-8be7-aee8adfa515f",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {",
+									"    pm.response.to.have.status(401);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/movies/1",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"movies",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/actors/1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "85cf17bd-41c5-4204-8ef9-d7e00a161ac7",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {",
+									"    pm.response.to.have.status(401);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/actors/1",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"actors",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "Casting Assistant is has no permissions for accessing privileged assests, and will represent a public request to all endpoints.",
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "casting-director",
+			"item": [
+				{
+					"name": "/movies",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "65a4b94b-628e-4bed-b24d-e2c7a128307c",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"value contains movies array\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.movies).to.be.an('array')",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/movies",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"movies"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/actors",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "935c1a82-44d2-4f04-9c61-bb0fbddf63bf",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"value contains actors array\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.actors).to.be.an('array')",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/actors",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"actors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/casts",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "94849131-54ca-4391-91f6-5c27f6e1321e",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"value contains casts array\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.casts).to.be.an('array')",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/casts",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"casts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/movies",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "0475eadc-c88f-4e90-a519-5139da53d167",
+								"exec": [
+									"pm.test(\"Status code is 403\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"title\": \"The Banality of Evil\",\n\t\"release_date\": \"2042/08/02\",\n\t\"cast_filled\": false\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/movies",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"movies"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/actors",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "317f96f3-1ef6-4aae-8180-8796f1b6fb97",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"name\": \"Bo Burnham\",\n\t\"age\": 29,\n\t\"gender\": \"Male\",\n\t\"seeking_role\": true\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/actors",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"actors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/casts",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "7d2b7d5c-93ef-41c1-897b-27d8c5ef5169",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"movie_id\": 5,\n\t\"actor_id\": 20\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/casts",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"casts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/movies/1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "6ae78e34-976a-4d6b-9d11-d770bd70f56f",
+								"exec": [
+									"pm.test(\"Status code is 403\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/movies/1",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"movies",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/actors/1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "2105e617-e043-4dd1-9358-54c7b012c7c7",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/actors/1",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"actors",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/casts/1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "dcd4ffef-da99-44ea-9d6b-31a4782a6a76",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/casts/1",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"casts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/movies/4",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c7eb3ff1-7a17-4338-8be7-aee8adfa515f",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"release_date\": \"2022/07/04\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/movies/4",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"movies",
+								"4"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/actors/23",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "85cf17bd-41c5-4204-8ef9-d7e00a161ac7",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"name\": \"BigTimeTimmyJim\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/actors/23",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"actors",
+								"23"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "Casting Assistant is has no permissions for accessing privileged assests, and will represent a public request to all endpoints.",
+			"auth": {
+				"type": "bearer",
+				"bearer": [
+					{
+						"key": "token",
+						"value": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjVMTzJ3Qk1Na21sQS0yZHR2ZUhTUCJ9.eyJpc3MiOiJodHRwczovL3ByZXN0aWdlLXdvcmxkd2lkZS5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NWVhMjdjMjY4YzZiZGUwYzhjYWQzOTBhIiwiYXVkIjoicHJlc3RpZ2Utd29ybGR3aWRlIiwiaWF0IjoxNTg3NzA3MDY4LCJleHAiOjE1ODc3MTQyNjgsImF6cCI6IlpBZ2U2UDdsQkdCQzNaZ0gyYkNqejBkZGgxR25XUWU3Iiwic2NvcGUiOiIiLCJwZXJtaXNzaW9ucyI6WyJkZWxldGU6YWN0b3JzIiwiZGVsZXRlOmNhc3RzIiwiZ2V0OmFjdG9ycyIsImdldDpjYXN0cyIsImdldDptb3ZpZXMiLCJwYXRjaDphY3RvcnMvaWQiLCJwYXRjaDptb3ZpZXMvaWQiLCJwb3N0OmFjdG9ycyIsInBvc3Q6Y2FzdHMiXX0.W-p3Tfd-MwlNGrSCpdWmWDD4WLj6HQ64Arq_2YYhmLxIoBDMkzde_Fks40L6kJxN638M73lq3kD-TFRmMyrNi0PLg-HBi42m7Cwsw0iij74kmjJaG0ozkSpOZAbd2zAeYeL52OQPcuHuxWozIynl6j54cedn5SL-PNnYk7pzbxq-GCa86f6Zghw3MVFaNIxfdR_wU-yaudK-DUeT91Z4XGg_M54_U6M_GWY2h96i189T-8OWKoaR_gbBdLkMpqZLSp9jecXtKamfL6k8H4eFVF80tQNWO4xX4rwDKtwPNwGWwPzADVAXG5aQsxVCO7SZdIPcSLsiI_DrcQ-a2kuHLQ",
+						"type": "string"
+					}
+				]
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "0dcd5f42-644a-4d75-8a69-057240f78cff",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "4c3727bd-596f-495c-a102-5a03de900ee4",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "executive-producer",
+			"item": [
+				{
+					"name": "/movies",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "65a4b94b-628e-4bed-b24d-e2c7a128307c",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"value contains movies array\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.movies).to.be.an('array')",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/movies",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"movies"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/actors",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "935c1a82-44d2-4f04-9c61-bb0fbddf63bf",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"value contains actors array\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.actors).to.be.an('array')",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/actors",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"actors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/casts",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "94849131-54ca-4391-91f6-5c27f6e1321e",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"value contains casts array\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.casts).to.be.an('array')",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/casts",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"casts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/movies",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "0475eadc-c88f-4e90-a519-5139da53d167",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"title\": \"The Banality of Evil\",\n\t\"release_date\": \"2042/08/02\",\n\t\"cast_filled\": false\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/movies",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"movies"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/actors",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "317f96f3-1ef6-4aae-8180-8796f1b6fb97",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"name\": \"Susan Sarandon\",\n\t\"age\": 73,\n\t\"gender\": \"Female\",\n\t\"seeking_role\": true\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/actors",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"actors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/casts",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "7d2b7d5c-93ef-41c1-897b-27d8c5ef5169",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"movie_id\": 2,\n\t\"actor_id\": 2\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/casts",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"casts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/movies/3",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "6ae78e34-976a-4d6b-9d11-d770bd70f56f",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/movies/3",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"movies",
+								"3"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/actors/3",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "2105e617-e043-4dd1-9358-54c7b012c7c7",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/actors/3",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"actors",
+								"3"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/casts/3",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "dcd4ffef-da99-44ea-9d6b-31a4782a6a76",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/casts/3",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"casts",
+								"3"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/movies/4",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c7eb3ff1-7a17-4338-8be7-aee8adfa515f",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"cast_filled\": false\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/movies/4",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"movies",
+								"4"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/actors/22",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "85cf17bd-41c5-4204-8ef9-d7e00a161ac7",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"seeking_role\": true\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/actors/22",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"actors",
+								"22"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "Casting Assistant is has no permissions for accessing privileged assests, and will represent a public request to all endpoints.",
+			"auth": {
+				"type": "bearer",
+				"bearer": [
+					{
+						"key": "token",
+						"value": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjVMTzJ3Qk1Na21sQS0yZHR2ZUhTUCJ9.eyJpc3MiOiJodHRwczovL3ByZXN0aWdlLXdvcmxkd2lkZS5hdXRoMC5jb20vIiwic3ViIjoiZ29vZ2xlLW9hdXRoMnwxMDA2NzE4MTMxODQ1MTQwNjQ1NjUiLCJhdWQiOlsicHJlc3RpZ2Utd29ybGR3aWRlIiwiaHR0cHM6Ly9wcmVzdGlnZS13b3JsZHdpZGUuYXV0aDAuY29tL3VzZXJpbmZvIl0sImlhdCI6MTU4NzcwODIyNCwiZXhwIjoxNTg3NzE1NDI0LCJhenAiOiJaQWdlNlA3bEJHQkMzWmdIMmJDanowZGRoMUduV1FlNyIsInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwiLCJwZXJtaXNzaW9ucyI6WyJkZWxldGU6YWN0b3JzIiwiZGVsZXRlOmNhc3RzIiwiZGVsZXRlOm1vdmllcyIsImdldDphY3RvcnMiLCJnZXQ6Y2FzdHMiLCJnZXQ6bW92aWVzIiwicGF0Y2g6YWN0b3JzL2lkIiwicGF0Y2g6bW92aWVzL2lkIiwicG9zdDphY3RvcnMiLCJwb3N0OmNhc3RzIiwicG9zdDptb3ZpZXMiXX0.avXt7eY3EOU9n4frrWDAn1FJnp9bb1528fGxxOlzZ-9uAeSg038qe1hiT0vwBAglgzvZ-1nPNBf6NhdTWEnyIp65W60Hj4WBygk8SXVecnutG1ObM8WZFqmWh-pKUCZtFm1QW5K91O8TTvwSfHzYsWk53PYRx2E0TJ_b3aGz0LYRwSAYtjHJCwF4OZeYyLRjd0kAXXDGOlD0ipMOPQDh8uKAuE4dPr5TXU9y5mQuKomLs_j41ytOT2EA8yaLR7d9tIVmHXPvoCoGa4lo1gacSp-AJIFpaBGgqTViQ9PcMvO5y369GjgcxbnmzAap3KwbfNKxYSNGJ7YW9XQ4P_I4fg",
+						"type": "string"
+					}
+				]
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "85aed97e-5133-4e14-bf5e-9fbb8effe4f7",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "40a34b4c-da57-40a8-a35b-7e941ef945a3",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3fc0c547-a8bb-42fa-9ddc-e84acee18ff7",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "e62e1f71-fb93-431f-bc15-226d9e2abd78",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"id": "07452f4a-030d-44d8-bd31-05bb2837af35",
+			"key": "host",
+			"value": "localhost:5000",
+			"type": "string"
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,4 +4,4 @@ Flask-Migrate
 Flask-Cors
 unittest2
 psycopg2-binary==2.8.5
-jose
+python-jose

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ Flask-Migrate
 Flask-Cors
 unittest2
 psycopg2-binary==2.8.5
+jose


### PR DESCRIPTION
## What does this PR do? 

This PR adds Auth0 authorization to the app by adding an auth.py file that creates the AuthError template for handling any authorization/permissions restrictions. This is done by creating an account on Auth0 for this app, setting up the application, api, permissions, and roles, and then assigning users to roles. 

This includes adding a requires_authorization decorator to the majority of the endpoints. Unfortunately this seems to have broken the majority of the tests that were previously written. To assist with the test coverage a Postman collection has been added that contains tests, as well as verified jwts created by Auth0 for this application, and are good for the next 7 days. 

## Where should the reviewer start?

Reviewers should start be examining how the auth.py file and how it is arranged. Also revisit the app.py file to see how the decorators and additional error handlers have been incorporated into the route handlers. Finally, open up the Postman collection and run the test suite located within there, while working with a freshly seeded database. Every test but one will pass, but if you refresh the database and then run that test first it will pass. Not sure what is causing the test to fail, but it seems to still be posting to the database regardless. 

## Can this be manually tested?

Yes, please see the Postman collection that has been added